### PR TITLE
normalized module name on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":"AOEPeople/Aoe_CacheRefresh",
+    "name":"aoepeople/aoe_cacherefresh",
     "type":"magento-module",
     "license":"OSL-3.0",
     "homepage":"https://github.com/aoepeople/Aoe_CacheRefresh",


### PR DESCRIPTION
This little change on composer.json is required to be able to submit the module on a packagist instance
